### PR TITLE
add functions for companion_relative_to_absolute_position and visualize_nrs_ifu_fov

### DIFF
--- a/breads/jwst_tools/planning.py
+++ b/breads/jwst_tools/planning.py
@@ -1,0 +1,90 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pysiaf
+import astropy.units as u
+
+def visualize_nrs_ifu_fov(comp_name, comp_sep, comp_pa, v3pa, center_on = 'star',
+                          show_inner_diff_spikes=False):
+    """ Visualize NIRSpec IFU FOV for a companion"""
+	# Disclaimer: Written in a bit of a rush; code could be cleaned up some still...
+
+    comp_rel_pa = v3pa - comp_pa.to_value(u.deg)
+    comp_rel_pa_rad = np.deg2rad(comp_rel_pa)
+    comp_sep_as = comp_sep.to_value(u.arcsec)
+
+    # Setup figure draf siaf
+    plt.figure()
+    nrs_siaf = pysiaf.Siaf('NIRSpec')
+    for apname in nrs_siaf.apernames:
+        if 'IFU_SLICE' in apname:
+            nrs_siaf.apertures[apname].plot(frame='tel', color='gray', alpha=0.5)
+
+
+    v2ref = nrs_siaf.apertures['NRS_FULL_IFU'].V2Ref
+    v3ref = nrs_siaf.apertures['NRS_FULL_IFU'].V3Ref
+
+    # How should the FOV be centered?
+    if center_on.lower() == 'star':
+        v2star = v2ref
+        v3star = v3ref
+    elif center_on.lower().startswith('comp'):
+        v2star = v2ref + np.sin(comp_rel_pa_rad)*comp_sep_as
+        v3star = v3ref - np.cos(comp_rel_pa_rad)*comp_sep_as
+    elif center_on.lower().startswith('midpoint'):
+        v2star = v2ref + np.sin(comp_rel_pa_rad)*comp_sep_as* 0.5
+        v3star = v3ref - np.cos(comp_rel_pa_rad)*comp_sep_as* 0.5
+    plt.plot(v2star, v3star, color='black', marker='o')
+
+
+    for angle in range(6):
+        ang_rad = np.deg2rad(angle*60)
+        # Big diffraction spikes
+        spikelen = 2
+        plt.plot([v2star, v2star-np.sin(ang_rad)*spikelen], [v3star, v3star+np.cos(ang_rad)*spikelen],
+                 color='black', lw=1, marker='none')
+        # smaller inner diffraction spikes
+        if show_inner_diff_spikes:
+            ang_rad = np.deg2rad(angle*60+30)
+            spikelen = 0.5
+            plt.plot([v2star, v2star-np.sin(ang_rad)*spikelen], [v3star, v3star+np.cos(ang_rad)*spikelen],
+                     color='black', lw=2, marker='none')
+    # Extra horizontal spikes from the +V3 SM strut
+    for angle in range(2):
+        ang_rad = np.deg2rad(angle*180 + 90)
+        spikelen = 1.5
+        plt.plot([v2star, v2star-np.sin(ang_rad)*spikelen], [v3star, v3star+np.cos(ang_rad)*spikelen],
+                 color='black', lw=1, marker='none')
+
+
+    arrowlen=2.3
+    plt.arrow(v2star, v3star, -np.sin(np.deg2rad(v3pa))*arrowlen, np.cos(np.deg2rad(v3pa))*arrowlen,
+                 color='red', lw=3, head_width=0.1)
+    plt.text(v2star -np.sin(np.deg2rad(v3pa))*arrowlen, v3star + np.cos(np.deg2rad(v3pa))*arrowlen,
+              '   N', color='red')
+    arrowlen=1.3
+    plt.arrow(v2star, v3star, -np.sin(np.deg2rad(v3pa-90))*arrowlen, np.cos(np.deg2rad(v3pa-90))*arrowlen,
+                 color='red', lw=2, head_width=0.1)
+    plt.text(v2star -np.sin(np.deg2rad(v3pa-90))*arrowlen, v3star + np.cos(np.deg2rad(v3pa-90))*arrowlen,
+              '   E', color='red')
+
+
+    comp_rel_pa = v3pa - comp_pa.to_value(u.deg)
+    comp_rel_pa_rad = np.deg2rad(comp_rel_pa)
+    #print(comp_pa, comp_rel_pa)
+    plt.plot([v2star-np.sin(comp_rel_pa_rad)*comp_sep.to_value(u.arcsec)],
+             [v3star+np.cos(comp_rel_pa_rad)*comp_sep.to_value(u.arcsec)],
+                 color='blue', lw=1, marker='s')
+    plt.text(v2star-np.sin(comp_rel_pa_rad)*(comp_sep.to_value(u.arcsec)+0.5),
+             v3star+np.cos(comp_rel_pa_rad)*(comp_sep.to_value(u.arcsec)+0.5),
+             comp_name,    color='blue')
+
+    slice_V3IdlYAngle = nrs_siaf.apertures['NRS_IFU_SLICE00'].V3IdlYAngle
+
+    plt.text(298.7, -499.3, "IFUalign X axis. Bottom of NRS detectors", rotation=slice_V3IdlYAngle-90, fontsize=8, color='green',
+            horizontalalignment='center', verticalalignment='center')
+    plt.text(301., -499.7, "IFUalign Y axis. ", rotation=slice_V3IdlYAngle-180, fontsize=8, color='green',
+            horizontalalignment='center', verticalalignment='center')
+    plt.text(301.2, -496.9, "Top of NRS detectosr", rotation=slice_V3IdlYAngle-90, fontsize=8, color='green',
+            horizontalalignment='center', verticalalignment='center')
+
+    plt.title(f'{comp_name} at V3PA={v3pa}')


### PR DESCRIPTION
This adds a function for computing the absolute ICRS coordinates of a companion on some specified epoch, based on host star coords and proper motion. I.e. this is the calculation we did for setting up the pointing of the 51 Eri b or HD 19467 B observations in APT. I just took that and packaged it up into a function so it's easy to script and repeat for other targets consistently. 

This now also adds a function for visualizing the NIRSpec IFU field of view for planning a companion observation. 


**Example code:**
```
import breads.utils, astropy.units as u
breads.utils.companion_relative_to_absolute_position('51 Eri', '51 Eri b',
                                                    comp_sep=0.295339*u.arcsec, comp_pa=105.997*u.deg,
                                                    obs_date = '2025-01-01T00:00')
```
That will output: 
```
**HOST STAR:**
Retrieving SIMBAD coordinates for 51 Eri
Coordinates at J2000:  04h37m36.1326s -02d28m24.775s
Coordinates at 2025-01-01T00:00:  04h37m36.20608551s -02d28m26.37574384s
Proper motion  pm_ra_cosdec: 44.049 mas / yr	pm_dec: -64.028 mas / yr
Parallax : 33.439 mas

**COMPANION:**
51 Eri b has r=0.295339 arcsec, pa=105.997 deg, which is (dDec,dR.A.) = -0.081 arcsec, 0.284 arcsec
51 Eri b ICRS coords at 2025-01-01T00:00: 04h37m36.22502999s -02d28m26.45713543s

        Crosscheck PA: 105.997 deg  should equal 105.997 deg
        Crosscheck sep: 0.295339 arcsec  should equal 0.295339 arcsec
        if the above are not equal then something went wrong in this calculation.

**COMPANION ABSOLUTE POINTING INFO FOR APT:**
	Name:			51 Eri b
	ICRS coordinates:	04 37 36.22502999 -02 28 26.45713543
	Epoch:			2025.00
	Proper Motion:		RA: 44.049 mas / yr	Dec: -64.028 mas / yr
	Annual Parallax:	0.0334 arcsec
```


**Example code:**
```
from breads.jwst_utils.planning import visualize_nrs_ifu_fov
visualize_nrs_ifu_fov('GJ 504 B', 2.5*u.arcsec, 315*u.degree, v3pa=273, center_on='comp')
```

![Unknown-8](https://github.com/user-attachments/assets/78a9a0ed-4d1c-40a9-b863-70de313275c3)

