### PR TITLE
add tutorials page to the docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,7 @@ Breads has been developed by Jean-Baptiste Ruffio (UC San Diego) and collaborato
 
    overview.rst
    installation.rst
+   tutorials.rst
    data_classes.rst
    forward_models.rst
    fitting.rst

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,0 +1,5 @@
+Tutorials
+=============
+
+
+ - Using atmosphere models via species. `Tutorial notebook here <https://github.com/jruffio/breads/blob/main/demos/atm_utils_tutorial.ipynb>`_ . 


### PR DESCRIPTION
From our hack session. Created a new tutorials page which will link to the tutorial noteb…ooks on github. 

I'm also using this as an example for making pull requests. 