### PR TITLE
Cleanup imports

### DIFF
--- a/breads/atm_utils.py
+++ b/breads/atm_utils.py
@@ -1,24 +1,23 @@
-from breads.utils import broaden
+import os
+import sys
+from contextlib import redirect_stdout
+from io import StringIO
 
+import astropy.units as u
+import h5py
+import matplotlib.pyplot as plt
+import numpy as np
 import species
+from astropy import constants as const
+from scipy.interpolate import RegularGridInterpolator
 from species.data.database import Database
+from species.phot.syn_phot import SyntheticPhotometry
 from species.read.read_model import ReadModel
+
+from breads.utils import broaden
 
 species.SpeciesInit()
 database = Database()
-
-import h5py
-import numpy as np
-import matplotlib.pyplot as plt
-from scipy.interpolate import RegularGridInterpolator
-from species.phot.syn_phot import SyntheticPhotometry
-import astropy.units as u
-from astropy import constants as const
-
-from contextlib import redirect_stdout
-from io import StringIO
-import sys
-import os
 
 def rprint(string):
     sys.stdout.write('\r'+str(string))

--- a/breads/calibration.py
+++ b/breads/calibration.py
@@ -1,16 +1,17 @@
-import numpy as np
+import multiprocessing as mp
+from copy import deepcopy
+from itertools import repeat
+from warnings import warn
+
+import astropy.io.fits as pyfits
 import astropy.units as u
+import numpy as np
+from photutils.aperture import EllipticalAperture, aperture_photometry
+from scipy.optimize import curve_fit, lsq_linear, minimize
+
 import breads.utils as utils
 from breads.instruments.instrument import Instrument
-from scipy.optimize import curve_fit, lsq_linear, minimize
-from copy import deepcopy
-import multiprocessing as mp
-from itertools import repeat
-import sys # for printing in mp, and error prints
-from warnings import warn
-import astropy.constants as const
-from photutils.aperture import EllipticalAperture, aperture_photometry
-import astropy.io.fits as pyfits
+
 
 #############################
 # OH line calibration code

--- a/breads/fit.py
+++ b/breads/fit.py
@@ -1,9 +1,9 @@
+from copy import copy
+
+import matplotlib.pyplot as plt
 import numpy as np
 from scipy.optimize import lsq_linear
 from scipy.special import loggamma
-import matplotlib.pyplot as plt
-import warnings
-from copy import copy
 
 __all__ =  ('fitfm', 'log_prob', 'combined_log_prob', 'nlog_prob')
 

--- a/breads/fm/hc_atmgrid_2dsplinefm_jwst_nirspec_cal.py
+++ b/breads/fm/hc_atmgrid_2dsplinefm_jwst_nirspec_cal.py
@@ -1,15 +1,11 @@
-import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
-from PyAstronomy import pyasl
 import astropy.units as u
-
-from breads.utils import broaden
-# from breads.utils import LPFvsHPF
+import numpy as np
+from PyAstronomy import pyasl
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
 from breads.utils import get_spline_model
+
 
 
 # pos: (x,y) or fiber, position of the companion
@@ -124,7 +120,6 @@ def hc_atmgrid_2dsplinefm_jwst_nirspec_cal(nonlin_paras, dataobj, ifuy_array=Non
     valid_pix_map = map_of_valid_traces*\
                     (dist2pl_array<3*dist2pl_max)*np.isfinite(trace_id_map)*np.isfinite(data)*\
                     np.isfinite(bad_pixels)*(noise!=0)*np.isfinite(comp_spec)
-    import matplotlib.pyplot as plt
     # plt.imshow(valid_pix_map,origin="lower")
     # plt.show()
     where_finite = np.where(valid_pix_map)

--- a/breads/fm/hc_atmgrid_2dsplinefm_jwst_nirspec_cal_FixedSlit.py
+++ b/breads/fm/hc_atmgrid_2dsplinefm_jwst_nirspec_cal_FixedSlit.py
@@ -1,13 +1,8 @@
-import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
-from PyAstronomy import pyasl
 import astropy.units as u
-
-from breads.utils import broaden
-# from breads.utils import LPFvsHPF
+import numpy as np
+from PyAstronomy import pyasl
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
 from breads.utils import get_spline_model
 

--- a/breads/fm/hc_atmgrid_hpffm.py
+++ b/breads/fm/hc_atmgrid_hpffm.py
@@ -1,12 +1,11 @@
 import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
 from PyAstronomy import pyasl
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
-from breads.utils import broaden
 from breads.utils import LPFvsHPF
+from breads.utils import broaden
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/hc_atmgrid_hpffm.py
+++ b/breads/fm/hc_atmgrid_hpffm.py
@@ -4,24 +4,8 @@ from astropy import constants as const
 from scipy.interpolate import interp1d
 
 from breads.utils import LPFvsHPF
-from breads.utils import broaden
+from breads.utils import broaden, pixgauss2d
 
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
 
 # pos: (x,y) or fiber, position of the companion
 def hc_atmgrid_hpffm(nonlin_paras, cubeobj, atm_grid=None, atm_grid_wvs=None, transmission=None, star_spectrum=None,boxw=1, psfw=1.2,

--- a/breads/fm/hc_atmgrid_splinefm.py
+++ b/breads/fm/hc_atmgrid_splinefm.py
@@ -3,24 +3,8 @@ from PyAstronomy import pyasl
 from astropy import constants as const
 from scipy.interpolate import interp1d
 
-from breads.utils import get_spline_model
+from breads.utils import get_spline_model, pixgauss2d
 
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
 
 # pos: (x,y) or fiber, position of the companion
 def hc_atmgrid_splinefm(nonlin_paras, cubeobj, atm_grid=None, atm_grid_wvs=None, transmission=None, star_spectrum=None,boxw=1, psfw=1.2,nodes=20,

--- a/breads/fm/hc_atmgrid_splinefm.py
+++ b/breads/fm/hc_atmgrid_splinefm.py
@@ -1,14 +1,10 @@
 import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
 from PyAstronomy import pyasl
-
-from breads.utils import broaden
-# from breads.utils import LPFvsHPF
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
 from breads.utils import get_spline_model
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/hc_atmgrid_splinefm_jwst_nirspec.py
+++ b/breads/fm/hc_atmgrid_splinefm_jwst_nirspec.py
@@ -1,14 +1,10 @@
 import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
 from PyAstronomy import pyasl
-
-from breads.utils import broaden
-# from breads.utils import LPFvsHPF
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
 from breads.utils import get_spline_model
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/hc_atmgrid_splinefm_jwst_nirspec.py
+++ b/breads/fm/hc_atmgrid_splinefm_jwst_nirspec.py
@@ -3,24 +3,8 @@ from PyAstronomy import pyasl
 from astropy import constants as const
 from scipy.interpolate import interp1d
 
-from breads.utils import get_spline_model
+from breads.utils import get_spline_model, pixgauss2d
 
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
 
 # pos: (x,y) or fiber, position of the companion
 def hc_atmgrid_splinefm_jwst_nirspec(nonlin_paras, cubeobj, atm_grid=None, atm_grid_wvs=None, transmission=None, star_spectrum=None,boxw=1, psfw=1.2,nodes=20,

--- a/breads/fm/hc_atmgrid_splinefm_jwst_nirspec_cal.py
+++ b/breads/fm/hc_atmgrid_splinefm_jwst_nirspec_cal.py
@@ -1,15 +1,11 @@
-import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
-from PyAstronomy import pyasl
 import astropy.units as u
-
-from breads.utils import broaden
-# from breads.utils import LPFvsHPF
+import numpy as np
+from PyAstronomy import pyasl
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
 from breads.utils import get_spline_model
+
 
 
 # pos: (x,y) or fiber, position of the companion

--- a/breads/fm/hc_atmgrid_splinefm_jwst_nirspec_cal_FixedSlit.py
+++ b/breads/fm/hc_atmgrid_splinefm_jwst_nirspec_cal_FixedSlit.py
@@ -1,13 +1,8 @@
-import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
-from PyAstronomy import pyasl
 import astropy.units as u
-
-from breads.utils import broaden
-# from breads.utils import LPFvsHPF
+import numpy as np
+from PyAstronomy import pyasl
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
 from breads.utils import get_spline_model
 

--- a/breads/fm/hc_hpffm.py
+++ b/breads/fm/hc_hpffm.py
@@ -2,24 +2,7 @@ import numpy as np
 from astropy import constants as const
 
 from breads.utils import LPFvsHPF
-from breads.utils import broaden
-
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
+from breads.utils import broaden, pixgauss2d
 
 
 def hc_hpffm(nonlin_paras, cubeobj, planet_f=None, transmission=None, star_spectrum=None,boxw=1, psfw=1.2,

--- a/breads/fm/hc_hpffm.py
+++ b/breads/fm/hc_hpffm.py
@@ -1,10 +1,9 @@
 import numpy as np
-from copy import copy
-import pandas as pd
 from astropy import constants as const
 
-from breads.utils import broaden
 from breads.utils import LPFvsHPF
+from breads.utils import broaden
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/hc_kpicrvfm.py
+++ b/breads/fm/hc_kpicrvfm.py
@@ -3,24 +3,7 @@ import scipy.ndimage as ndi
 from astropy import constants as const
 from scipy.interpolate import interp1d
 
-from breads.utils import get_spline_model, scale_psg
-
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
+from breads.utils import get_spline_model, scale_psg, pixgauss2d
 
 
 

--- a/breads/fm/hc_kpicrvfm.py
+++ b/breads/fm/hc_kpicrvfm.py
@@ -1,11 +1,10 @@
 import numpy as np
-
-from scipy.interpolate import InterpolatedUnivariateSpline
-from astropy import constants as const
 import scipy.ndimage as ndi
+from astropy import constants as const
 from scipy.interpolate import interp1d
 
 from breads.utils import get_spline_model, scale_psg
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/hc_mask_splinefm.py
+++ b/breads/fm/hc_mask_splinefm.py
@@ -5,24 +5,8 @@ import numpy as np
 from astropy import constants as const
 from scipy.optimize import lsq_linear
 
-from breads.utils import get_spline_model
+from breads.utils import get_spline_model, pixgauss2d
 
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, sigx, sigy, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * sigx * sigy) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 / (sigx ** 2) + (yA - yhdgrid) ** 2 / (sigy ** 2)))
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
 
 def set_nodes(cont_stamp, noise_stamp, wavelengths, nodes, optimize_nodes, p, wid_mov=None, knot_margin=1e-4):
     data_f = np.divide(np.nanmedian(cont_stamp, axis=(1,2)), np.nanmedian(noise_stamp, axis=(1,2)))

--- a/breads/fm/hc_mask_splinefm.py
+++ b/breads/fm/hc_mask_splinefm.py
@@ -1,11 +1,12 @@
-import numpy as np
-import matplotlib.pyplot as plt
-from scipy.interpolate import InterpolatedUnivariateSpline
-from astropy import constants as const
-from copy import deepcopy
-from breads.utils import get_spline_model
 from copy import copy
+
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy import constants as const
 from scipy.optimize import lsq_linear
+
+from breads.utils import get_spline_model
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/hc_splinefm.py
+++ b/breads/fm/hc_splinefm.py
@@ -1,9 +1,8 @@
 import numpy as np
-
-from scipy.interpolate import InterpolatedUnivariateSpline
 from astropy import constants as const
 
 from breads.utils import get_spline_model
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/hc_splinefm.py
+++ b/breads/fm/hc_splinefm.py
@@ -1,24 +1,8 @@
 import numpy as np
 from astropy import constants as const
 
-from breads.utils import get_spline_model
+from breads.utils import get_spline_model, pixgauss2d
 
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
 
 
 def hc_splinefm(nonlin_paras, cubeobj, planet_f=None, transmission=None, star_spectrum=None,boxw=1, psfw=1.2,nodes=20,

--- a/breads/fm/hc_splinefm_jwst_nirspec.py
+++ b/breads/fm/hc_splinefm_jwst_nirspec.py
@@ -1,9 +1,8 @@
 import numpy as np
-
-from scipy.interpolate import InterpolatedUnivariateSpline
 from astropy import constants as const
 
 from breads.utils import get_spline_model
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/hc_splinefm_jwst_nirspec.py
+++ b/breads/fm/hc_splinefm_jwst_nirspec.py
@@ -1,24 +1,8 @@
 import numpy as np
 from astropy import constants as const
 
-from breads.utils import get_spline_model
+from breads.utils import get_spline_model, pixgauss2d
 
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
 
 
 def hc_splinefm_jwst_nirspec(nonlin_paras, cubeobj, planet_f=None, transmission=None, star_spectrum=None, boxw=1, psfw=1.2, nodes=20,

--- a/breads/fm/iso_atmgrid_doppler_hpffm.py
+++ b/breads/fm/iso_atmgrid_doppler_hpffm.py
@@ -1,14 +1,13 @@
 import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
 from PyAstronomy import pyasl
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
-from breads.utils import broaden
 from breads.utils import LPFvsHPF
+from breads.utils import broaden
 from breads.utils import broaden_kernel
 from breads.utils import get_spline_model
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/iso_atmgrid_doppler_hpffm.py
+++ b/breads/fm/iso_atmgrid_doppler_hpffm.py
@@ -6,24 +6,8 @@ from scipy.interpolate import interp1d
 from breads.utils import LPFvsHPF
 from breads.utils import broaden
 from breads.utils import broaden_kernel
-from breads.utils import get_spline_model
+from breads.utils import get_spline_model, pixgauss2d
 
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
 
 # pos: (x,y) or fiber, position of the companion
 def iso_atmgrid_doppler_hpffm(nonlin_paras, cubeobj, atm_grid=None, atm_grid_wvs=None, transmission=None,boxw=1, psfw=1.2,

--- a/breads/fm/iso_atmgrid_hpffm.py
+++ b/breads/fm/iso_atmgrid_hpffm.py
@@ -1,12 +1,11 @@
 import numpy as np
-from copy import copy
-import pandas as pd
-from astropy import constants as const
-from  scipy.interpolate import interp1d
 from PyAstronomy import pyasl
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
-from breads.utils import broaden
 from breads.utils import LPFvsHPF
+from breads.utils import broaden
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/iso_atmgrid_hpffm.py
+++ b/breads/fm/iso_atmgrid_hpffm.py
@@ -4,24 +4,9 @@ from astropy import constants as const
 from scipy.interpolate import interp1d
 
 from breads.utils import LPFvsHPF
-from breads.utils import broaden
+from breads.utils import broaden, pixgauss2d
 
 
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
 
 # pos: (x,y) or fiber, position of the companion
 def iso_atmgrid_hpffm(nonlin_paras, cubeobj, atm_grid=None, atm_grid_wvs=None, transmission=None,boxw=1, psfw=1.2,

--- a/breads/fm/iso_atmgrid_splinefm.py
+++ b/breads/fm/iso_atmgrid_splinefm.py
@@ -3,24 +3,7 @@ from PyAstronomy import pyasl
 from astropy import constants as const
 from scipy.interpolate import interp1d
 
-from breads.utils import get_spline_model
-
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
+from breads.utils import get_spline_model, pixgauss2d
 
 
 def iso_atmgrid_splinefm(nonlin_paras, cubeobj, atm_grid=None, atm_grid_wvs=None, transmission=None,boxw=1, psfw=1.2,nodes=20,badpixfraction=0.75,loc=None,fix_parameters=None):

--- a/breads/fm/iso_atmgrid_splinefm.py
+++ b/breads/fm/iso_atmgrid_splinefm.py
@@ -1,12 +1,10 @@
 import numpy as np
-
-from scipy.interpolate import InterpolatedUnivariateSpline
-from astropy import constants as const
-
-from  scipy.interpolate import interp1d
 from PyAstronomy import pyasl
+from astropy import constants as const
+from scipy.interpolate import interp1d
 
 from breads.utils import get_spline_model
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/iso_hpffm.py
+++ b/breads/fm/iso_hpffm.py
@@ -2,24 +2,7 @@ import numpy as np
 from astropy import constants as const
 
 from breads.utils import LPFvsHPF
-from breads.utils import broaden
-
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
+from breads.utils import broaden, pixgauss2d
 
 
 def iso_hpffm(nonlin_paras, cubeobj, planet_f=None, transmission=None,boxw=1, psfw=1.2,badpixfraction=0.75,

--- a/breads/fm/iso_hpffm.py
+++ b/breads/fm/iso_hpffm.py
@@ -1,11 +1,8 @@
 import numpy as np
-from copy import copy
-import pandas as pd
 from astropy import constants as const
 
-from breads.utils import broaden
 from breads.utils import LPFvsHPF
-
+from breads.utils import broaden
 
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):

--- a/breads/fm/iso_splinefm.py
+++ b/breads/fm/iso_splinefm.py
@@ -1,9 +1,8 @@
 import numpy as np
-
-from scipy.interpolate import InterpolatedUnivariateSpline
 from astropy import constants as const
 
 from breads.utils import get_spline_model
+
 
 def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
     """

--- a/breads/fm/iso_splinefm.py
+++ b/breads/fm/iso_splinefm.py
@@ -1,24 +1,7 @@
 import numpy as np
 from astropy import constants as const
 
-from breads.utils import get_spline_model
-
-
-def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
-    """
-    2d gaussian model. Documentation to be completed. Also faint of t
-    """
-    A, xA, yA, w, bkg = p
-    ny, nx = shape
-    if xhdgrid is None or yhdgrid is None:
-        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
-                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
-    else:
-        hdfactor = xhdgrid.shape[0] // ny
-    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
-        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
-    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
-    return gaussA + bkg
+from breads.utils import get_spline_model, pixgauss2d
 
 
 def iso_splinefm(nonlin_paras, cubeobj, planet_f=None, transmission=None, boxw=1, psfw=1.2,nodes=20,

--- a/breads/instruments/KPIC.py
+++ b/breads/instruments/KPIC.py
@@ -1,18 +1,16 @@
-from breads.instruments.instrument import Instrument
-import breads.utils as utils
-from warnings import warn
-import astropy.io.fits as pyfits
-import numpy as np
-import ctypes
-from astropy.coordinates import SkyCoord, EarthLocation
-import astropy.units as u
-from astropy.time import Time
+import warnings
 from copy import copy
 from copy import deepcopy
-from  scipy.interpolate import interp1d
-from breads.utils import findbadpix
+from warnings import warn
+
+import astropy.io.fits as pyfits
+import numpy as np
+from scipy.interpolate import interp1d
+
+from breads.instruments.instrument import Instrument
 from breads.utils import broaden
-import warnings
+from breads.utils import findbadpix
+
 
 class KPIC(Instrument):
     def __init__(self, spec=None, trace=None, wvs=None, err=None, badpix=None,baryrv=None,orders=None,combine_mode="planet",fiber_goal_list = None):

--- a/breads/instruments/OSIRIS.py
+++ b/breads/instruments/OSIRIS.py
@@ -1,20 +1,22 @@
-from matplotlib.pyplot import axis
-import matplotlib.pyplot as plt
 from breads.instruments.instrument import Instrument
 import breads.utils as utils
-from warnings import warn
-import astropy.io.fits as pyfits
-import numpy as np
-import ctypes
-from astropy.coordinates import SkyCoord, EarthLocation
-import astropy.units as u
-from astropy.time import Time
-from copy import copy, deepcopy
-from breads.utils import broaden
-from breads.calibration import SkyCalibration
 import multiprocessing as mp
+from copy import copy
 from itertools import repeat
+from warnings import warn
+
+import astropy.io.fits as pyfits
+import astropy.units as u
+import numpy as np
 import pandas as pd
+from astropy.coordinates import SkyCoord, EarthLocation
+from astropy.time import Time
+
+import breads.utils as utils
+from breads.calibration import SkyCalibration
+from breads.instruments.instrument import Instrument
+from breads.utils import broaden
+
 
 class OSIRIS(Instrument):
     def __init__(self, filename=None, skip_baryrv=False):

--- a/breads/instruments/instrument.py
+++ b/breads/instruments/instrument.py
@@ -1,6 +1,8 @@
 import os
-import breads.utils as utils
 from warnings import warn
+
+import breads.utils as utils
+
 
 class Instrument:
     def __init__(self, ins_type="custom", verbose=True):

--- a/breads/jwst_tools/planning.py
+++ b/breads/jwst_tools/planning.py
@@ -1,7 +1,8 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import pysiaf
 import astropy.units as u
+import matplotlib.pyplot as plt
+import numpy as np
+import pysiaf
+
 
 def visualize_nrs_fov(comp_name, comp_sep, comp_pa, v3pa, center_on = 'star',
                           show_inner_diff_spikes=True, diff_spike_len = 2,

--- a/breads/utils.py
+++ b/breads/utils.py
@@ -916,3 +916,20 @@ def companion_relative_to_absolute_position(star_name, comp_name, comp_sep, comp
         print(f'\tProper Motion:\t\tRA: {star_coord.pm_ra_cosdec:.3f}\tDec: {star_coord.pm_dec:.3f}')
         print(f'\tAnnual Parallax:\t{1/star_coord.distance.to_value(u.pc):.4f} arcsec')
     return planet_coord
+
+
+def pixgauss2d(p, shape, hdfactor=10, xhdgrid=None, yhdgrid=None):
+    """
+    2d gaussian model. Documentation to be completed. Also faint of t
+    """
+    A, xA, yA, w, bkg = p
+    ny, nx = shape
+    if xhdgrid is None or yhdgrid is None:
+        xhdgrid, yhdgrid = np.meshgrid(np.arange(hdfactor * nx).astype(np.float) / hdfactor,
+                                       np.arange(hdfactor * ny).astype(np.float) / hdfactor)
+    else:
+        hdfactor = xhdgrid.shape[0] // ny
+    gaussA_hd = A / (2 * np.pi * w ** 2) * np.exp(
+        -0.5 * ((xA - xhdgrid) ** 2 + (yA - yhdgrid) ** 2) / w ** 2)
+    gaussA = np.nanmean(np.reshape(gaussA_hd, (ny, hdfactor, nx, hdfactor)), axis=(1, 3))
+    return gaussA + bkg


### PR DESCRIPTION
Cleanup imports at start of files. No change to code functionality. 

1. Optimize imports: remove imports of unused packages, sort and organize import statements. Automated edits via PyCharm. 
2. Consolidate the dozen-plus copies of the `pixgauss2d` function in many files into one single copy in utils. 