### PR TITLE
Minor syntax fix to avoid unnecessary syntax warnings

### DIFF
--- a/breads/fit.py
+++ b/breads/fit.py
@@ -22,7 +22,7 @@ def fitfm(nonlin_paras, dataobj, fm_func, fm_paras,computeH0 = True,bounds = Non
         computeH0: If true (default), compute the probability of the model removing the first element of the linear
             model; See second ouput log_prob_H0. This can be used to compute the Bayes factor for a fixed set of
             non-linear parameters
-        bounds: (/!\ Caution: the calculation of log prob is only theoretically accurate if no bounds are used.)
+        bounds: (Caution: the calculation of log prob is only theoretically accurate if no bounds are used.)
             Bounds on the linear parameters used in lsq_linear as a tuple of arrays (min_vals, maxvals).
             e.g. ([0,0,...], [np.inf,np.inf,...]) default no bounds.
             Each numpy array must have shape (N_linear_parameters,).
@@ -296,7 +296,7 @@ def log_prob(nonlin_paras, dataobj, fm_func, fm_paras,nonlin_lnprior_func=None,b
         computeH0: If true (default), compute the probability of the model removing the first element of the linear
             model; See second ouput log_prob_H0. This can be used to compute the Bayes factor for a fixed set of
             non-linear parameters
-        bounds: (/!\ Caution: the calculation of log prob is only theoretically accurate if no bounds are used.)
+        bounds: (Caution: the calculation of log prob is only theoretically accurate if no bounds are used.)
             Bounds on the linear parameters used in lsq_linear as a tuple of arrays (min_vals, maxvals).
             e.g. ([0,0,...], [np.inf,np.inf,...]). default no bounds.
             Each numpy array must have shape (N_linear_parameters,).
@@ -346,7 +346,7 @@ def nlog_prob(nonlin_paras, dataobj, fm_func, fm_paras,nonlin_lnprior_func=None,
         computeH0: If true (default), compute the probability of the model removing the first element of the linear
             model; See second ouput log_prob_H0. This can be used to compute the Bayes factor for a fixed set of
             non-linear parameters
-        bounds: (/!\ Caution: the calculation of log prob is only theoretically accurate if no bounds are used.)
+        bounds: (Caution: the calculation of log prob is only theoretically accurate if no bounds are used.)
             Bounds on the linear parameters used in lsq_linear as a tuple of arrays (min_vals, maxvals).
             e.g. ([0,0,...], [np.inf,np.inf,...]) default no bounds.
             Each numpy array must have shape (N_linear_parameters,).


### PR DESCRIPTION
Tiny PR with a trivial fix. On recent python versions, some extra backslash characters in a doc string cause warnings: 

```
 > ipython
Python 3.12.7 | packaged by conda-forge | (main, Oct  4 2024, 15:57:01) [Clang 17.0.6 ]

In [1]: import breads
/Users/mperrin/Dropbox (Personal)/Documents/software/git/breads/breads/fit.py:13: SyntaxWarning: invalid escape sequence '\ '
  """
/Users/mperrin/Dropbox (Personal)/Documents/software/git/breads/breads/fit.py:287: SyntaxWarning: invalid escape sequence '\ '
  """
/Users/mperrin/Dropbox (Personal)/Documents/software/git/breads/breads/fit.py:337: SyntaxWarning: invalid escape sequence '\ '
  """
```

This PR gets rid of those warnings. 