### PR TITLE
add progress bar display during long build_cube_task calculations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
     "emcee",
     "PyAstronomy",
     "pandas>2.0.0",
-    "astroquery>=0.4.9"
-
+    "astroquery>=0.4.9",
+    "tqdm"
 ]
 
 [project.license]


### PR DESCRIPTION
As discussed in Slack, this PR adds a progress bar display during long build_cube_task iterations for JWST NIRSpec analyses. 

<img width="710" alt="Screenshot 2025-04-18 at 9 35 34 AM" src="https://github.com/user-attachments/assets/44af7c54-b03b-4b10-b9c4-abc543eced8d" />

